### PR TITLE
Put bucket name in path instead of subdomain

### DIFF
--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -15,7 +15,7 @@ class S3UrlGenerator
 
     auth_string = 'AWS %s:%s' % [aws_access_key_id, signed_base64]
 
-    @url = 'https://%s.s3.amazonaws.com%s' % [bucket, path]
+    @url = 'https://s3.amazonaws.com/%s%s' % [bucket, path]
     @headers = { 'date' => now, 'authorization' => auth_string }
   end
 end


### PR DESCRIPTION
If your bucket name has a "." in it, then the SSL cert will not match and throw an error. Putting the bucket name in the path fixes that problem.